### PR TITLE
Update react 16 compat

### DIFF
--- a/src/FixedDataTableBufferedRows.react.js
+++ b/src/FixedDataTableBufferedRows.react.js
@@ -1,3 +1,4 @@
+var PropTypes = require('prop-types');
 /**
  * Copyright (c) 2015, Facebook, Inc.
  * All rights reserved.
@@ -19,8 +20,6 @@ var cx = require('cx');
 var emptyFunction = require('emptyFunction');
 var joinClasses = require('joinClasses');
 var translateDOMPositionXY = require('translateDOMPositionXY');
-
-var {PropTypes} = React;
 
 var FixedDataTableBufferedRows = createReactClass({
   displayName: "FixedDataTableBufferedRows",

--- a/src/FixedDataTableBufferedRows.react.js
+++ b/src/FixedDataTableBufferedRows.react.js
@@ -69,6 +69,7 @@ var FixedDataTableBufferedRows = createReactClass({
 
   componentDidMount() {
     setTimeout(this._updateBuffer, 1000);
+    this._isMounted = true;
   },
 
   componentWillReceiveProps(/*object*/ nextProps) {
@@ -96,7 +97,7 @@ var FixedDataTableBufferedRows = createReactClass({
   },
 
   _updateBuffer() {
-    if (this.isMounted()) {
+    if (this._isMounted) {
       this.setState({
         rowsToRender: this._rowBuffer.getRowsWithUpdatedBuffer(),
       });
@@ -110,6 +111,7 @@ var FixedDataTableBufferedRows = createReactClass({
 
   componentWillUnmount() {
     this._staticRowArray.length = 0;
+    this._isMounted = false;
   },
 
   render() /*object*/ {

--- a/src/FixedDataTableBufferedRows.react.js
+++ b/src/FixedDataTableBufferedRows.react.js
@@ -11,6 +11,7 @@
  */
 
 var React = require('React');
+var createReactClass = require('create-react-class');
 var FixedDataTableRowBuffer = require('FixedDataTableRowBuffer');
 var FixedDataTableRow = require('FixedDataTableRow.react');
 
@@ -21,7 +22,8 @@ var translateDOMPositionXY = require('translateDOMPositionXY');
 
 var {PropTypes} = React;
 
-var FixedDataTableBufferedRows = React.createClass({
+var FixedDataTableBufferedRows = createReactClass({
+  displayName: "FixedDataTableBufferedRows",
 
   propTypes: {
     isScrolling: PropTypes.bool,
@@ -174,7 +176,7 @@ var FixedDataTableBufferedRows = React.createClass({
     return this.props.rowHeightGetter ?
       this.props.rowHeightGetter(index) :
       this.props.defaultRowHeight;
-  },
+  }
 });
 
 module.exports = FixedDataTableBufferedRows;

--- a/src/FixedDataTableCell.react.js
+++ b/src/FixedDataTableCell.react.js
@@ -12,14 +12,13 @@
 
 var FixedDataTableCellDefault = require('FixedDataTableCellDefault.react');
 var FixedDataTableHelper = require('FixedDataTableHelper');
+var PropTypes = require('prop-types');
 var React = require('React');
 var createReactClass = require('create-react-class');
 var cx = require('cx');
 var joinClasses = require('joinClasses');
 
 var DIR_SIGN = FixedDataTableHelper.DIR_SIGN;
-
-var {PropTypes} = React;
 
 var DEFAULT_PROPS = {
   align: 'left',

--- a/src/FixedDataTableCell.react.js
+++ b/src/FixedDataTableCell.react.js
@@ -13,6 +13,7 @@
 var FixedDataTableCellDefault = require('FixedDataTableCellDefault.react');
 var FixedDataTableHelper = require('FixedDataTableHelper');
 var React = require('React');
+var createReactClass = require('create-react-class');
 var cx = require('cx');
 var joinClasses = require('joinClasses');
 
@@ -25,7 +26,8 @@ var DEFAULT_PROPS = {
   highlighted: false,
 };
 
-var FixedDataTableCell = React.createClass({
+var FixedDataTableCell = createReactClass({
+  displayName: "FixedDataTableCell",
 
   /**
    * PropTypes are disabled in this component, because having them on slows
@@ -179,7 +181,7 @@ var FixedDataTableCell = React.createClass({
       this.props.columnKey,
       event
     );
-  },
+  }
 });
 
 module.exports = FixedDataTableCell;

--- a/src/FixedDataTableCellDefault.react.js
+++ b/src/FixedDataTableCellDefault.react.js
@@ -1,3 +1,4 @@
+var PropTypes = require('prop-types');
 /**
  * Copyright (c) 2015, Facebook, Inc.
  * All rights reserved.
@@ -14,8 +15,6 @@ var React = require('React');
 
 var cx = require('cx');
 var joinClasses = require('joinClasses');
-
-var {PropTypes} = React;
 
 /**
  * Component that handles default cell layout and styling.

--- a/src/FixedDataTableCellDefault.react.js
+++ b/src/FixedDataTableCellDefault.react.js
@@ -40,8 +40,8 @@ var {PropTypes} = React;
  * );
  * ```
  */
-var FixedDataTableCellDefault = React.createClass({
-  propTypes: {
+class FixedDataTableCellDefault extends React.Component {
+  static propTypes = {
 
     /**
      * Outer height of the cell.
@@ -61,7 +61,7 @@ var FixedDataTableCellDefault = React.createClass({
       PropTypes.string,
       PropTypes.number,
     ]),
-  },
+  };
 
   render() {
     var {height, width, style, className, children, ...props} = this.props;
@@ -98,7 +98,7 @@ var FixedDataTableCellDefault = React.createClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
 module.exports = FixedDataTableCellDefault;

--- a/src/FixedDataTableCellGroup.react.js
+++ b/src/FixedDataTableCellGroup.react.js
@@ -14,6 +14,7 @@
 
 var FixedDataTableHelper = require('FixedDataTableHelper');
 var React = require('React');
+var createReactClass = require('create-react-class');
 var FixedDataTableCell = require('FixedDataTableCell.react');
 
 var cx = require('cx');
@@ -23,7 +24,8 @@ var {PropTypes} = React;
 
 var DIR_SIGN = FixedDataTableHelper.DIR_SIGN;
 
-var FixedDataTableCellGroupImpl = React.createClass({
+var FixedDataTableCellGroupImpl = createReactClass({
+  displayName: "FixedDataTableCellGroupImpl",
 
   /**
    * PropTypes are disabled in this component, because having them on slows
@@ -133,10 +135,11 @@ var FixedDataTableCellGroupImpl = React.createClass({
       width += columns[i].props.width;
     }
     return width;
-  },
+  }
 });
 
-var FixedDataTableCellGroup = React.createClass({
+var FixedDataTableCellGroup = createReactClass({
+  displayName: "FixedDataTableCellGroup",
 
   /**
    * PropTypes are disabled in this component, because having them on slows
@@ -218,7 +221,7 @@ var FixedDataTableCellGroup = React.createClass({
       columnKey,
       event
     );
-  },
+  }
 });
 
 

--- a/src/FixedDataTableCellGroup.react.js
+++ b/src/FixedDataTableCellGroup.react.js
@@ -13,14 +13,13 @@
 'use strict';
 
 var FixedDataTableHelper = require('FixedDataTableHelper');
+var PropTypes = require('prop-types');
 var React = require('React');
 var createReactClass = require('create-react-class');
 var FixedDataTableCell = require('FixedDataTableCell.react');
 
 var cx = require('cx');
 var translateDOMPositionXY = require('translateDOMPositionXY');
-
-var {PropTypes} = React;
 
 var DIR_SIGN = FixedDataTableHelper.DIR_SIGN;
 

--- a/src/FixedDataTableColumnGroupNew.react.js
+++ b/src/FixedDataTableColumnGroupNew.react.js
@@ -17,12 +17,10 @@ var {PropTypes} = React;
 /**
  * Component that defines the attributes of a table column group.
  */
-var FixedDataTableColumnGroup = React.createClass({
-  statics: {
-    __TableColumnGroup__: true,
-  },
+class FixedDataTableColumnGroup extends React.Component {
+  static __TableColumnGroup__ = true;
 
-  propTypes: {
+  static propTypes = {
     /**
      * The horizontal alignment of the table cell content.
      */
@@ -57,13 +55,11 @@ var FixedDataTableColumnGroup = React.createClass({
       PropTypes.func,
     ]),
 
-  },
+  };
 
-  getDefaultProps() /*object*/ {
-    return {
-      fixed: false,
-    };
-  },
+  static defaultProps = {
+	fixed: false,
+  };
 
   render() {
     if (__DEV__) {
@@ -72,7 +68,7 @@ var FixedDataTableColumnGroup = React.createClass({
       );
     }
     return null;
-  },
-});
+  }
+}
 
 module.exports = FixedDataTableColumnGroup;

--- a/src/FixedDataTableColumnGroupNew.react.js
+++ b/src/FixedDataTableColumnGroupNew.react.js
@@ -1,3 +1,4 @@
+var PropTypes = require('prop-types');
 /**
  * Copyright (c) 2015, Facebook, Inc.
  * All rights reserved.
@@ -11,8 +12,6 @@
  */
 
 var React = require('React');
-
-var {PropTypes} = React;
 
 /**
  * Component that defines the attributes of a table column group.

--- a/src/FixedDataTableColumnNew.react.js
+++ b/src/FixedDataTableColumnNew.react.js
@@ -17,173 +17,169 @@ var {PropTypes} = React;
 /**
  * Component that defines the attributes of table column.
  */
-var FixedDataTableColumn = React.createClass({
-  statics: {
-    __TableColumn__: true
-  },
+class FixedDataTableColumn extends React.Component {
+ static __TableColumn__ = true;
 
-  propTypes: {
-    /**
-     * The horizontal alignment of the table cell content.
-     */
-    align: PropTypes.oneOf(['left', 'center', 'right']),
+ static propTypes = {
+   /**
+	* The horizontal alignment of the table cell content.
+	*/
+   align: PropTypes.oneOf(['left', 'center', 'right']),
 
-    /**
-     * Controls if the column is fixed when scrolling in the X axis.
-     */
-    fixed: PropTypes.bool,
+   /**
+	* Controls if the column is fixed when scrolling in the X axis.
+	*/
+   fixed: PropTypes.bool,
 
-    /**
-     * The header cell for this column.
-     * This can either be a string a React element, or a function that generates
-     * a React Element. Passing in a string will render a default header cell
-     * with that string. By default, the React element passed in can expect to
-     * receive the following props:
-     *
-     * ```
-     * props: {
-     *   columnKey: string // (of the column, if given)
-     *   height: number // (supplied from the Table or rowHeightGetter)
-     *   width: number // (supplied from the Column)
-     * }
-     * ```
-     *
-     * Because you are passing in your own React element, you can feel free to
-     * pass in whatever props you may want or need.
-     *
-     * If you pass in a function, you will receive the same props object as the
-     * first argument.
-     */
-    header: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.func,
-    ]),
+   /**
+	* The header cell for this column.
+	* This can either be a string a React element, or a function that generates
+	* a React Element. Passing in a string will render a default header cell
+	* with that string. By default, the React element passed in can expect to
+	* receive the following props:
+	*
+	* ```
+	* props: {
+	*   columnKey: string // (of the column, if given)
+	*   height: number // (supplied from the Table or rowHeightGetter)
+	*   width: number // (supplied from the Column)
+	* }
+	* ```
+	*
+	* Because you are passing in your own React element, you can feel free to
+	* pass in whatever props you may want or need.
+	*
+	* If you pass in a function, you will receive the same props object as the
+	* first argument.
+	*/
+   header: PropTypes.oneOfType([
+	 PropTypes.node,
+	 PropTypes.func,
+   ]),
 
-    /**
-     * This is the body cell that will be cloned for this column.
-     * This can either be a string a React element, or a function that generates
-     * a React Element. Passing in a string will render a default header cell
-     * with that string. By default, the React element passed in can expect to
-     * receive the following props:
-     *
-     * ```
-     * props: {
-     *   rowIndex; number // (the row index of the cell)
-     *   columnKey: string // (of the column, if given)
-     *   height: number // (supplied from the Table or rowHeightGetter)
-     *   width: number // (supplied from the Column)
-     * }
-     * ```
-     *
-     * Because you are passing in your own React element, you can feel free to
-     * pass in whatever props you may want or need.
-     *
-     * If you pass in a function, you will receive the same props object as the
-     * first argument.
-     */
-    cell: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.func,
-    ]),
+   /**
+	* This is the body cell that will be cloned for this column.
+	* This can either be a string a React element, or a function that generates
+	* a React Element. Passing in a string will render a default header cell
+	* with that string. By default, the React element passed in can expect to
+	* receive the following props:
+	*
+	* ```
+	* props: {
+	*   rowIndex; number // (the row index of the cell)
+	*   columnKey: string // (of the column, if given)
+	*   height: number // (supplied from the Table or rowHeightGetter)
+	*   width: number // (supplied from the Column)
+	* }
+	* ```
+	*
+	* Because you are passing in your own React element, you can feel free to
+	* pass in whatever props you may want or need.
+	*
+	* If you pass in a function, you will receive the same props object as the
+	* first argument.
+	*/
+   cell: PropTypes.oneOfType([
+	 PropTypes.node,
+	 PropTypes.func,
+   ]),
 
-    /**
-     * This is the footer cell for this column.
-     * This can either be a string a React element, or a function that generates
-     * a React Element. Passing in a string will render a default header cell
-     * with that string. By default, the React element passed in can expect to
-     * receive the following props:
-     *
-     * ```
-     * props: {
-     *   columnKey: string // (of the column, if given)
-     *   height: number // (supplied from the Table or rowHeightGetter)
-     *   width: number // (supplied from the Column)
-     * }
-     * ```
-     *
-     * Because you are passing in your own React element, you can feel free to
-     * pass in whatever props you may want or need.
-     *
-     * If you pass in a function, you will receive the same props object as the
-     * first argument.
-     */
-    footer: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.func,
-    ]),
+   /**
+	* This is the footer cell for this column.
+	* This can either be a string a React element, or a function that generates
+	* a React Element. Passing in a string will render a default header cell
+	* with that string. By default, the React element passed in can expect to
+	* receive the following props:
+	*
+	* ```
+	* props: {
+	*   columnKey: string // (of the column, if given)
+	*   height: number // (supplied from the Table or rowHeightGetter)
+	*   width: number // (supplied from the Column)
+	* }
+	* ```
+	*
+	* Because you are passing in your own React element, you can feel free to
+	* pass in whatever props you may want or need.
+	*
+	* If you pass in a function, you will receive the same props object as the
+	* first argument.
+	*/
+   footer: PropTypes.oneOfType([
+	 PropTypes.node,
+	 PropTypes.func,
+   ]),
 
-    /**
-     * This is used to uniquely identify the column, and is not required unless
-     * you a resizing columns. This will be the key given in the
-     * `onColumnResizeEndCallback` on the Table.
-     */
-    columnKey: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
+   /**
+	* This is used to uniquely identify the column, and is not required unless
+	* you a resizing columns. This will be the key given in the
+	* `onColumnResizeEndCallback` on the Table.
+	*/
+   columnKey: PropTypes.oneOfType([
+	 PropTypes.string,
+	 PropTypes.number,
+   ]),
 
-    /**
-     * The pixel width of the column.
-     */
-    width: PropTypes.number.isRequired,
+   /**
+	* The pixel width of the column.
+	*/
+   width: PropTypes.number.isRequired,
 
-    /**
-     * If this is a resizable column this is its minimum pixel width.
-     */
-    minWidth: PropTypes.number,
+   /**
+	* If this is a resizable column this is its minimum pixel width.
+	*/
+   minWidth: PropTypes.number,
 
-    /**
-     * If this is a resizable column this is its maximum pixel width.
-     */
-    maxWidth: PropTypes.number,
+   /**
+	* If this is a resizable column this is its maximum pixel width.
+	*/
+   maxWidth: PropTypes.number,
 
-    /**
-     * The grow factor relative to other columns. Same as the flex-grow API
-     * from http://www.w3.org/TR/css3-flexbox/. Basically, take any available
-     * extra width and distribute it proportionally according to all columns'
-     * flexGrow values. Defaults to zero (no-flexing).
-     */
-    flexGrow: PropTypes.number,
+   /**
+	* The grow factor relative to other columns. Same as the flex-grow API
+	* from http://www.w3.org/TR/css3-flexbox/. Basically, take any available
+	* extra width and distribute it proportionally according to all columns'
+	* flexGrow values. Defaults to zero (no-flexing).
+	*/
+   flexGrow: PropTypes.number,
 
-    /**
-     * Whether the column can be resized with the
-     * FixedDataTableColumnResizeHandle. Please note that if a column
-     * has a flex grow, once you resize the column this will be set to 0.
-     *
-     * This property only provides the UI for the column resizing. If this
-     * is set to true, you will need to set the onColumnResizeEndCallback table
-     * property and render your columns appropriately.
-     */
-    isResizable: PropTypes.bool,
+   /**
+	* Whether the column can be resized with the
+	* FixedDataTableColumnResizeHandle. Please note that if a column
+	* has a flex grow, once you resize the column this will be set to 0.
+	*
+	* This property only provides the UI for the column resizing. If this
+	* is set to true, you will need to set the onColumnResizeEndCallback table
+	* property and render your columns appropriately.
+	*/
+   isResizable: PropTypes.bool,
 
-    /**
-     * Whether cells in this column can be removed from document when outside
-     * of viewport as a result of horizontal scrolling.
-     * Setting this property to true allows the table to not render cells in
-     * particular column that are outside of viewport for visible rows. This
-     * allows to create table with many columns and not have vertical scrolling
-     * performance drop.
-     * Setting the property to false will keep previous behaviour and keep
-     * cell rendered if the row it belongs to is visible.
-     */
-    allowCellsRecycling: PropTypes.bool,
-  },
+   /**
+	* Whether cells in this column can be removed from document when outside
+	* of viewport as a result of horizontal scrolling.
+	* Setting this property to true allows the table to not render cells in
+	* particular column that are outside of viewport for visible rows. This
+	* allows to create table with many columns and not have vertical scrolling
+	* performance drop.
+	* Setting the property to false will keep previous behaviour and keep
+	* cell rendered if the row it belongs to is visible.
+	*/
+   allowCellsRecycling: PropTypes.bool,
+ };
 
-  getDefaultProps() /*object*/ {
-    return {
-      allowCellsRecycling: false,
-      fixed: false,
-    };
-  },
+ static defaultProps = {
+   allowCellsRecycling: false,
+   fixed: false,
+ };
 
-  render() {
-    if (__DEV__) {
-      throw new Error(
-        'Component <FixedDataTableColumn /> should never render'
-      );
-    }
-    return null;
-  },
-});
+ render() {
+   if (__DEV__) {
+	 throw new Error(
+	   'Component <FixedDataTableColumn /> should never render'
+	 );
+   }
+   return null;
+ }
+}
 
 module.exports = FixedDataTableColumn;

--- a/src/FixedDataTableColumnNew.react.js
+++ b/src/FixedDataTableColumnNew.react.js
@@ -1,3 +1,4 @@
+var PropTypes = require('prop-types');
 /**
  * Copyright (c) 2015, Facebook, Inc.
  * All rights reserved.
@@ -11,8 +12,6 @@
  */
 
 var React = require('React');
-
-var {PropTypes} = React;
 
 /**
  * Component that defines the attributes of table column.

--- a/src/FixedDataTableColumnResizeHandle.react.js
+++ b/src/FixedDataTableColumnResizeHandle.react.js
@@ -17,6 +17,7 @@
 var DOMMouseMoveTracker = require('DOMMouseMoveTracker');
 var Locale = require('Locale');
 var React = require('React');
+var createReactClass = require('create-react-class');
 var ReactComponentWithPureRenderMixin = require('ReactComponentWithPureRenderMixin');
 
 var clamp = require('clamp');
@@ -24,7 +25,8 @@ var cx = require('cx');
 
 var {PropTypes} = React;
 
-var FixedDataTableColumnResizeHandle = React.createClass({
+var FixedDataTableColumnResizeHandle = createReactClass({
+  displayName: "FixedDataTableColumnResizeHandle",
   mixins: [ReactComponentWithPureRenderMixin],
 
   propTypes: {
@@ -161,7 +163,7 @@ var FixedDataTableColumnResizeHandle = React.createClass({
       this.state.width,
       this.props.columnKey
     );
-  },
+  }
 });
 
 module.exports = FixedDataTableColumnResizeHandle;

--- a/src/FixedDataTableColumnResizeHandle.react.js
+++ b/src/FixedDataTableColumnResizeHandle.react.js
@@ -16,14 +16,13 @@
 
 var DOMMouseMoveTracker = require('DOMMouseMoveTracker');
 var Locale = require('Locale');
+var PropTypes = require('prop-types');
 var React = require('React');
 var createReactClass = require('create-react-class');
 var ReactComponentWithPureRenderMixin = require('ReactComponentWithPureRenderMixin');
 
 var clamp = require('clamp');
 var cx = require('cx');
-
-var {PropTypes} = React;
 
 var FixedDataTableColumnResizeHandle = createReactClass({
   displayName: "FixedDataTableColumnResizeHandle",

--- a/src/FixedDataTableNew.react.js
+++ b/src/FixedDataTableNew.react.js
@@ -14,6 +14,7 @@
 /*eslint no-bitwise:1*/
 
 var React = require('React');
+var createReactClass = require('create-react-class');
 var ReactComponentWithPureRenderMixin = require('ReactComponentWithPureRenderMixin');
 var ReactWheelHandler = require('ReactWheelHandler');
 var Scrollbar = require('Scrollbar.react');
@@ -86,7 +87,8 @@ var CELL = 'cell';
  * - Scrollable Body Columns: The body columns that move while scrolling
  *   vertically or horizontally.
  */
-var FixedDataTable = React.createClass({
+var FixedDataTable = createReactClass({
+  displayName: "FixedDataTable",
 
   propTypes: {
 
@@ -1007,7 +1009,6 @@ var FixedDataTable = React.createClass({
     }
   },
 
-
   _onHorizontalScroll(/*number*/ scrollPos) {
     if (this.isMounted() && scrollPos !== this.state.scrollX) {
       if (!this._isScrolling) {
@@ -1053,11 +1054,13 @@ var FixedDataTable = React.createClass({
         this.props.onScrollEnd(this.state.scrollX, this.state.scrollY);
       }
     }
-  },
+  }
 });
 
-var HorizontalScrollbar = React.createClass({
+var HorizontalScrollbar = createReactClass({
+  displayName: "HorizontalScrollbar",
   mixins: [ReactComponentWithPureRenderMixin],
+
   propTypes: {
     contentSize: PropTypes.number.isRequired,
     offset: PropTypes.number.isRequired,
@@ -1100,7 +1103,7 @@ var HorizontalScrollbar = React.createClass({
         </div>
       </div>
     );
-  },
+  }
 });
 
 module.exports = FixedDataTable;

--- a/src/FixedDataTableNew.react.js
+++ b/src/FixedDataTableNew.react.js
@@ -1,3 +1,4 @@
+var PropTypes = require('prop-types');
 /**
  * Copyright (c) 2015, Facebook, Inc.
  * All rights reserved.
@@ -32,7 +33,6 @@ var joinClasses = require('joinClasses');
 var shallowEqual = require('shallowEqual');
 var translateDOMPositionXY = require('translateDOMPositionXY');
 
-var {PropTypes} = React;
 var ReactChildren = React.Children;
 
 var EMPTY_OBJECT = {};

--- a/src/FixedDataTableNew.react.js
+++ b/src/FixedDataTableNew.react.js
@@ -356,6 +356,7 @@ var FixedDataTable = createReactClass({
 
   componentDidMount() {
     this._reportContentHeight();
+    this._isMounted = true;
   },
 
   componentWillReceiveProps(/*object*/ nextProps) {
@@ -580,6 +581,10 @@ var FixedDataTable = createReactClass({
         {horizontalScrollbar}
       </div>
     );
+  },
+
+  componentWillUnmount() {
+    this._isMounted = false;
   },
 
   _renderRows(/*number*/ offsetTop) /*object*/ {
@@ -977,7 +982,7 @@ var FixedDataTable = createReactClass({
   },
 
   _onWheel(/*number*/ deltaX, /*number*/ deltaY) {
-    if (this.isMounted()) {
+    if (this._isMounted) {
       if (!this._isScrolling) {
         this._didScrollStart();
       }
@@ -1010,7 +1015,7 @@ var FixedDataTable = createReactClass({
   },
 
   _onHorizontalScroll(/*number*/ scrollPos) {
-    if (this.isMounted() && scrollPos !== this.state.scrollX) {
+    if (this._isMounted && scrollPos !== this.state.scrollX) {
       if (!this._isScrolling) {
         this._didScrollStart();
       }
@@ -1022,7 +1027,7 @@ var FixedDataTable = createReactClass({
   },
 
   _onVerticalScroll(/*number*/ scrollPos) {
-    if (this.isMounted() && scrollPos !== this.state.scrollY) {
+    if (this._isMounted && scrollPos !== this.state.scrollY) {
       if (!this._isScrolling) {
         this._didScrollStart();
       }
@@ -1038,7 +1043,7 @@ var FixedDataTable = createReactClass({
   },
 
   _didScrollStart() {
-    if (this.isMounted() && !this._isScrolling) {
+    if (this._isMounted && !this._isScrolling) {
       this._isScrolling = true;
       if (this.props.onScrollStart) {
         this.props.onScrollStart(this.state.scrollX, this.state.scrollY);
@@ -1047,7 +1052,7 @@ var FixedDataTable = createReactClass({
   },
 
   _didScrollStop() {
-    if (this.isMounted() && this._isScrolling) {
+    if (this._isMounted && this._isScrolling) {
       this._isScrolling = false;
       this.setState({redraw: true});
       if (this.props.onScrollEnd) {

--- a/src/FixedDataTableRow.react.js
+++ b/src/FixedDataTableRow.react.js
@@ -26,9 +26,8 @@ var {PropTypes} = React;
  * This component should not be used directly by developer. Instead,
  * only <FixedDataTable /> should use the component internally.
  */
-var FixedDataTableRowImpl = React.createClass({
-
-  propTypes: {
+class FixedDataTableRowImpl extends React.Component {
+  static propTypes = {
 
     isScrolling: PropTypes.bool,
 
@@ -84,7 +83,7 @@ var FixedDataTableRowImpl = React.createClass({
      * @param object event
      */
     onColumnResize: PropTypes.func,
-  },
+  };
 
   render() /*object*/ {
     var style = {
@@ -146,17 +145,17 @@ var FixedDataTableRowImpl = React.createClass({
         </div>
       </div>
     );
-  },
+  }
 
-  _getColumnsWidth(/*array*/ columns) /*number*/ {
+  _getColumnsWidth = /*array*/ columns => /*number*/ {
     var width = 0;
     for (var i = 0; i < columns.length; ++i) {
       width += columns[i].props.width;
     }
     return width;
-  },
+  };
 
-  _renderColumnsShadow(/*number*/ left) /*?object*/ {
+  _renderColumnsShadow = /*number*/ left => /*?object*/ {
     if (left > 0) {
       var className = cx({
         'fixedDataTableRowLayout/fixedColumnsDivider': true,
@@ -170,32 +169,31 @@ var FixedDataTableRowImpl = React.createClass({
       };
       return <div className={className} style={style} />;
     }
-  },
+  };
 
-  _onClick(/*object*/ event) {
+  _onClick = /*object*/ event => {
     this.props.onClick(event, this.props.index);
-  },
+  };
 
-  _onDoubleClick(/*object*/ event) {
+  _onDoubleClick = /*object*/ event => {
     this.props.onDoubleClick(event, this.props.index);
-  },
+  };
 
-  _onMouseDown(/*object*/ event) {
+  _onMouseDown = /*object*/ event => {
     this.props.onMouseDown(event, this.props.index);
-  },
+  };
 
-  _onMouseEnter(/*object*/ event) {
+  _onMouseEnter = /*object*/ event => {
     this.props.onMouseEnter(event, this.props.index);
-  },
+  };
 
-  _onMouseLeave(/*object*/ event) {
+  _onMouseLeave = /*object*/ event => {
     this.props.onMouseLeave(event, this.props.index);
-  },
-});
+  };
+}
 
-var FixedDataTableRow = React.createClass({
-
-  propTypes: {
+class FixedDataTableRow extends React.Component {
+  static propTypes = {
 
     isScrolling: PropTypes.bool,
 
@@ -219,7 +217,7 @@ var FixedDataTableRow = React.createClass({
      * Width of the row.
      */
     width: PropTypes.number.isRequired,
-  },
+  };
 
   render() /*object*/ {
     var style = {
@@ -240,8 +238,8 @@ var FixedDataTableRow = React.createClass({
         />
       </div>
     );
-  },
-});
+  }
+}
 
 
 module.exports = FixedDataTableRow;

--- a/src/FixedDataTableRow.react.js
+++ b/src/FixedDataTableRow.react.js
@@ -12,14 +12,14 @@
 
 'use strict';
 
+var PropTypes = require('prop-types');
+
 var React = require('React');
 var FixedDataTableCellGroup = require('FixedDataTableCellGroup.react');
 
 var cx = require('cx');
 var joinClasses = require('joinClasses');
 var translateDOMPositionXY = require('translateDOMPositionXY');
-
-var {PropTypes} = React;
 
 /**
  * Component that renders the row for <FixedDataTable />.

--- a/src/Scrollbar.react.js
+++ b/src/Scrollbar.react.js
@@ -13,6 +13,7 @@
 var DOMMouseMoveTracker = require('DOMMouseMoveTracker');
 var Keys = require('Keys');
 var React = require('React');
+var createReactClass = require('create-react-class');
 var ReactDOM = require('ReactDOM');
 var ReactComponentWithPureRenderMixin = require('ReactComponentWithPureRenderMixin');
 var ReactWheelHandler = require('ReactWheelHandler');
@@ -36,7 +37,8 @@ var KEYBOARD_SCROLL_AMOUNT = 40;
 
 var _lastScrolledScrollbar = null;
 
-var Scrollbar = React.createClass({
+var Scrollbar = createReactClass({
+  displayName: "Scrollbar",
   mixins: [ReactComponentWithPureRenderMixin],
 
   propTypes: {
@@ -502,7 +504,7 @@ var Scrollbar = React.createClass({
 
   _didScroll() {
     this.props.onScroll(this.state.position);
-  },
+  }
 });
 
 Scrollbar.KEYBOARD_SCROLL_AMOUNT = KEYBOARD_SCROLL_AMOUNT;

--- a/src/Scrollbar.react.js
+++ b/src/Scrollbar.react.js
@@ -197,6 +197,8 @@ var Scrollbar = createReactClass({
       this.state.position !== this.props.position) {
       this._didScroll();
     }
+
+    this._isMounted = true;
   },
 
   componentWillUnmount() {
@@ -206,6 +208,8 @@ var Scrollbar = createReactClass({
       _lastScrolledScrollbar = null;
     }
     delete this._mouseMoveTracker;
+
+    this._isMounted = false;
   },
 
   scrollBy(/*number*/ delta) {
@@ -466,7 +470,7 @@ var Scrollbar = createReactClass({
   },
 
   _blur() {
-    if (this.isMounted()) {
+    if (this._isMounted) {
       try {
         this._onBlur();
         ReactDOM.findDOMNode(this).blur();

--- a/src/Scrollbar.react.js
+++ b/src/Scrollbar.react.js
@@ -12,6 +12,7 @@
 
 var DOMMouseMoveTracker = require('DOMMouseMoveTracker');
 var Keys = require('Keys');
+var PropTypes = require('prop-types');
 var React = require('React');
 var createReactClass = require('create-react-class');
 var ReactDOM = require('ReactDOM');
@@ -22,8 +23,6 @@ var cssVar = require('cssVar');
 var cx = require('cx');
 var emptyFunction = require('emptyFunction');
 var translateDOMPositionXY = require('translateDOMPositionXY');
-
-var {PropTypes} = React;
 
 var UNSCROLLABLE_STATE = {
   position: 0,

--- a/src/transition/FixedDataTable.react.js
+++ b/src/transition/FixedDataTable.react.js
@@ -19,11 +19,11 @@
 
 'use strict';
 
+var PropTypes = require('prop-types');
+
 var React = require('React');
 
 var ReactChildren = React.Children;
-
-var {PropTypes} = React;
 
 // New Table API
 var Table = require('FixedDataTableNew.react');

--- a/src/transition/FixedDataTable.react.js
+++ b/src/transition/FixedDataTable.react.js
@@ -9,13 +9,13 @@
  * @providesModule FixedDataTable.react
  */
 
- /**
-  * TRANSITION SHIM
-  * This acts to provide an intermediate mapping from the old API to the new API
-  *
-  * Remove this entire file and replace the two lines in FixedDataTableRoot
-  * when ready to continue to the new API.
-  */
+/**
+ * TRANSITION SHIM
+ * This acts to provide an intermediate mapping from the old API to the new API
+ *
+ * Remove this entire file and replace the two lines in FixedDataTableRoot
+ * when ready to continue to the new API.
+ */
 
 'use strict';
 
@@ -105,8 +105,8 @@ function notifyDeprecated(prop, reason) {
  * - Scrollable Body Columns: The body columns that move while scrolling
  *   vertically or horizontally.
  */
-var TransitionTable = React.createClass({
-  propTypes: {
+class TransitionTable extends React.Component {
+  static propTypes = {
     /**
      * Pixel width of table. If all columns do not fit,
      * a horizontal scrollbar will appear.
@@ -303,17 +303,18 @@ var TransitionTable = React.createClass({
      * Whether a column is currently being resized.
      */
     isColumnResizing: PropTypes.bool,
-  },
+  };
 
-  getInitialState() {
-    // Throw warnings on deprecated props.
-    var state = {};
-    state.needsMigration = this._checkDeprecations();
+  constructor(props, context) {
+    super(props, context);
+	// Throw warnings on deprecated props.
+	var state = {};
+	state.needsMigration = this._checkDeprecations();
 
-    return state;
-  },
+	this.state = state;
+  }
 
-  _checkDeprecations() {
+  _checkDeprecations = () => {
     var needsMigration = false;
 
     if (this.props.rowGetter) {
@@ -398,10 +399,10 @@ var TransitionTable = React.createClass({
     });
 
     return needsMigration;
-  },
+  };
 
   // Wrapper for onRow callbacks, since we don't have rowData at that level.
-  _onRowAction(props, callback) {
+  _onRowAction = (props, callback) => {
     if (!callback) {
       return undefined;
     }
@@ -413,9 +414,9 @@ var TransitionTable = React.createClass({
         (props.rowGetter && props.rowGetter(rowIndex)) || EMPTY_OBJECT
       );
     };
-  },
+  };
 
-  _transformColumn(column, tableProps, key) {
+  _transformColumn = (column, tableProps, key) => {
 
     var props = column.props;
 
@@ -462,9 +463,9 @@ var TransitionTable = React.createClass({
         />
       );
     }
-  },
+  };
 
-  _transformColumnGroup(group, tableProps, key, labels) {
+  _transformColumnGroup = (group, tableProps, key, labels) => {
     var props = group.props;
 
     var j = 0;
@@ -490,9 +491,9 @@ var TransitionTable = React.createClass({
         {columns}
       </ColumnGroup>
     );
-  },
+  };
 
-  _convertedColumns(needsMigration) {
+  _convertedColumns = needsMigration => {
     // If we don't need to migrate, map directly to the new API.
     if (!needsMigration) {
       return ReactChildren.map(this.props.children, (child) => {
@@ -539,7 +540,7 @@ var TransitionTable = React.createClass({
       i++;
       return child;
     });
-  },
+  };
 
   render() {
     var props = this.props;
@@ -555,7 +556,7 @@ var TransitionTable = React.createClass({
         {this._convertedColumns(this.state.needsMigration)}
       </Table>
     );
-  },
-});
+  }
+}
 
 module.exports = TransitionTable;

--- a/src/transition/FixedDataTableCellTransition.react.js
+++ b/src/transition/FixedDataTableCellTransition.react.js
@@ -1,3 +1,4 @@
+var PropTypes = require('prop-types');
 /**
  * Copyright (c) 2015, Facebook, Inc.
  * All rights reserved.
@@ -18,7 +19,6 @@
  */
 
 var React = require('React');
-var {PropTypes} = React;
 
 var cx = require('cx');
 var joinClasses = require('joinClasses');

--- a/src/transition/FixedDataTableCellTransition.react.js
+++ b/src/transition/FixedDataTableCellTransition.react.js
@@ -26,9 +26,8 @@ var shallowEqual = require('shallowEqual');
 
 var CellDefault = require('FixedDataTableCellDefault.react');
 
-var TransitionCell = React.createClass({
-
-  propTypes: {
+class TransitionCell extends React.Component {
+  static propTypes = {
     label: PropTypes.string, // header, footer
     className: PropTypes.string,
     rowIndex: PropTypes.number,
@@ -46,7 +45,7 @@ var TransitionCell = React.createClass({
     height: PropTypes.number,
     isHeaderCell: PropTypes.bool, // header
     isFooterCell: PropTypes.bool, // footer
-  },
+  };
 
   shouldComponentUpdate(/*object*/ nextProps): boolean {
     var update = false;
@@ -74,9 +73,9 @@ var TransitionCell = React.createClass({
     this._cellData = cellData;
 
     return update || !shallowEqual(nextProps, this.props);
-  },
+  }
 
-  _getCellData(props) {
+  _getCellData = props => {
     var dataKey = props.dataKey;
     if (dataKey == null) {
       return null;
@@ -106,9 +105,9 @@ var TransitionCell = React.createClass({
     if (props.headerDataGetter) {
       return props.headerDataGetter[dataKey];
     }
-  },
+  };
 
-  _getRowData(props): Object {
+  _getRowData = (props): Object => {
     if (props.rowGetter) {
       return props.rowGetter(props.rowIndex) || {};
     }
@@ -122,7 +121,7 @@ var TransitionCell = React.createClass({
     }
 
     return {};
-  },
+  };
 
   render() {
     var props = this.props;
@@ -214,6 +213,6 @@ var TransitionCell = React.createClass({
     );
 
   }
-});
+}
 
 module.exports = TransitionCell;

--- a/src/transition/FixedDataTableColumn.react.js
+++ b/src/transition/FixedDataTableColumn.react.js
@@ -19,10 +19,8 @@
 
 var React = require('React');
 
-var TransitionColumn = React.createClass({
-  statics: {
-    __TableColumn__: true
-  },
+class TransitionColumn extends React.Component {
+  static __TableColumn__ = true;
 
   render() {
     if (__DEV__) {
@@ -32,6 +30,6 @@ var TransitionColumn = React.createClass({
     }
     return null;
   }
-});
+}
 
 module.exports = TransitionColumn;

--- a/src/transition/FixedDataTableColumnGroup.react.js
+++ b/src/transition/FixedDataTableColumnGroup.react.js
@@ -9,20 +9,18 @@
  * @providesModule FixedDataTableColumnGroup.react
  */
 
- /**
-  * TRANSITION SHIM
-  * This provides an intermediate mapping from the old API to the new API.
-  *
-  * When ready, remove this file and rename the providesModule in
-  * FixedDataTableColumnNew.react
-  */
+/**
+ * TRANSITION SHIM
+ * This provides an intermediate mapping from the old API to the new API.
+ *
+ * When ready, remove this file and rename the providesModule in
+ * FixedDataTableColumnNew.react
+ */
 
 var React = require('React');
 
-var TransitionColumnGroup = React.createClass({
-  statics: {
-    __TableColumnGroup__: true,
-  },
+class TransitionColumnGroup extends React.Component {
+  static __TableColumnGroup__ = true;
 
   render() {
     if (__DEV__) {
@@ -32,6 +30,6 @@ var TransitionColumnGroup = React.createClass({
     }
     return null;
   }
-});
+}
 
 module.exports = TransitionColumnGroup;


### PR DESCRIPTION
## What I tried first

* Replacing our forked version of the deprecated `fixed-data-table` library with the currently maintained [fixed-data-table-2](https://github.com/schrodinger/fixed-data-table-2)
* However, there were issues. Specifically, [this issue](https://github.com/schrodinger/fixed-data-table-2/issues/288). A new plan was called for.

## What I did here
Updated our fork of the original `fixed-data-table` for compatibility with React 16. The steps involved were:

* Running the [codemod](https://github.com/reactjs/react-codemod#explanation-of-the-new-es2015-class-transform-with-property-initializers) to replace `React.createClass with ES6 classes`
* Running the [codemod](https://github.com/reactjs/react-codemod#react-proptypes-to-prop-types) for replacing `React.propTypes` with the `prop-types` library
* Replacing usages of the deprecated `isMounted` method with checking of an instance property, `_isMounted`, which gets initialized in `componentDidMount` and set to `false` in `componentWillUnmount`

## Test plan
* Clone this repo and checkout this branch, along with `master` on `BC/client`. Run `npm install`, `npm run build-npm`, and `npm run build-dist` in the directory for this repo.
* Then copy the newly created `dist` and `internal` directories from this repo to your `client/node_modules/@buildingconnected/fixed-data-table` directory.
* Navigate to all views with fixed data tables -- the project table, bidders table, proposals tab, and contacts list. Interact with the tables and confirm that nothing is broken and no errors or warnings appear in the console.
* NOTE: You will still see a warning about an unknown `columnKey` prop when you view the bidders table. This will potentially be addressed in a followup, but should not be harmful.