### PR TITLE
[BLT-1033] Fix columnKey warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildingconnected/fixed-data-table",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "A React table component designed to allow presenting thousands of rows of data.",
   "main": "main.js",
   "peerDependencies": {

--- a/src/FixedDataTableCell.react.js
+++ b/src/FixedDataTableCell.react.js
@@ -151,6 +151,10 @@ var FixedDataTableCell = createReactClass({
 
     var content;
     if (React.isValidElement(props.cell)) {
+      if (props.cell.type === 'div') {
+        delete cellProps.columnKey;
+      }
+
       content = React.cloneElement(props.cell, cellProps);
     } else if (typeof props.cell === 'function') {
       content = props.cell(cellProps);


### PR DESCRIPTION
## Jira
https://building-connected.atlassian.net/browse/BLT-1033

## Description
Tired of getting this damn warning in the console *every time* you navigate to Bid Leveling???

<img width="867" alt="screen shot 2019-01-14 at 7 41 10 pm" src="https://user-images.githubusercontent.com/3289413/51219336-4e322f80-18e5-11e9-9ba1-1287e8cf17f9.png">

Well let’s fix it!

The issue stems from here:

https://github.com/BuildingConnected/fixed-data-table/blob/d22f6ac21d8a135cd509d0d86961a2de94d3c2a0/src/FixedDataTableCell.react.js#L142-L154

When `React.isValidElement(props.cell)` returns `true`, which is when `props.cell` is a React element, this code clones it and applies the props listed in `cellProps`. https://reactjs.org/docs/react-api.html#isvalidelement

A React element’s type can only be “a tag name string (such as `div` or `span`), a React component type (a class or a function), or a React fragment type.” https://reactjs.org/docs/react-api.html#createelement

React elements that have a type which is a tag name string (such as `div` or `span`) are React DOM elements.

When a prop is passed to a React DOM element, React interprets those props as HTML attributes and attempts to apply them, which will give a warning if a prop is not a valid HTML attribute. https://reactjs.org/warnings/unknown-prop.html

In our case, if `props.cell`'s type is a `div`, as in, it is a React DOM element, the code passes `cellProps`'s `columnKey` property as a prop to `props.cell`'s clone, which React interprets as a HTML attribute. Because `columnKey` is not a valid HTML attribute, the warning is given.

To fix this, if `props.cell`'s type is a `div`, `cellProps`'s `columnKey` property should be deleted with the `delete` operator before it is cloned.

From git blame, this code was developed by Facebook and wasn’t something we added after forking. https://github.com/BuildingConnected/fixed-data-table/blame/dde6379d4a3041a2a03883fb165653c8f4ce37f4/src/FixedDataTableCell.react.js#L153

## Test Plan
1. Copy and paste the added code into the exact same place in the same file, `FixedDataTableCell.react.js`, in your local `client` repo, which is located at `client/node_modules/@buildingconnected/fixed-data-table/internal/FixedDataTableCell.react.js`
2. Navigate to Bid Leveling
3. Verify the warning no longer occurs

## Regression Test Plan
It isn't feasible to test all functionality of every single type of cell that we use. However, we may instead use a proof: Because of the conditional, this change only effects `props.cell` when it is a `div`, and when it is a `div` it is a React DOM element and cannot be a React component, which means it cannot have user defined methods that could possibly utilize a `columnKey` prop. Therefore, it is highly unlikely that a function exists requiring the `columnKey` prop that will now have an error due to `columnKey` not being defined.